### PR TITLE
Add Feb 2020 Wisconsin elections

### DIFF
--- a/WI/2020.json
+++ b/WI/2020.json
@@ -1,0 +1,115 @@
+{
+    "meta": {
+        "limit": 1000,
+        "next": null,
+        "offset": 0,
+        "previous": null,
+        "total_count": 2
+    },
+    "objects": [
+        {
+            "absentee_and_provisional": false,
+            "cong_dist_level": false,
+            "cong_dist_level_status": "",
+            "county_level": false,
+            "county_level_status": "",
+            "direct_link": "",
+            "direct_links": [
+                "https://elections.wi.gov/sites/elections.wi.gov/files/Ward%20by%20Ward%20Report_All%20Offices_Spring%20Primary_2_18_20.xlsx"
+            ],
+            "end_date": "2020-02-18",
+            "gov": false,
+            "house": false,
+            "id": 1894,
+            "organization": {
+                "city": "",
+                "fec_page": "http://www.fec.gov/pubrec/cfsdd/widir.htm7",
+                "gov_agency": true,
+                "gov_level": "state",
+                "id": 17,
+                "name": "Wisconsin Elections Commission",
+                "resource_uri": "/api/v1/organization/17/",
+                "slug": "wi-gab",
+                "state": "WI",
+                "street": "",
+                "url": "http://elections.wi.gov/"
+            },
+            "portal_link": "https://elections.wi.gov/node/6697",
+            "precinct_level": true,
+            "precinct_level_status": "yes",
+            "prez": false,
+            "primary_note": "Non-partisan",
+            "primary_type": "other",
+            "race_type": "primary",
+            "resource_uri": "/api/v1/election/1894/",
+            "result_type": "certified",
+            "senate": false,
+            "special": false,
+            "start_date": "2020-02-18",
+            "state": {
+                "name": "Wisconsin",
+                "postal": "WI",
+                "resource_uri": "/api/v1/state/WI/"
+            },
+            "state_leg": false,
+            "state_leg_level": false,
+            "state_leg_level_status": "",
+            "state_level": false,
+            "state_level_status": "",
+            "state_officers": true,
+            "user_fullname": "Davies, Nick"
+        },
+        {
+            "absentee_and_provisional": false,
+            "cong_dist_level": false,
+            "cong_dist_level_status": "",
+            "county_level": false,
+            "county_level_status": "",
+            "direct_link": "",
+            "direct_links": [
+                "https://elections.wi.gov/sites/elections.wi.gov/files/Ward%20by%20Ward%20Report_All%20Offices_Spring%20Primary_2_18_20.xlsx"
+            ],
+            "end_date": "2020-02-18",
+            "gov": false,
+            "house": true,
+            "id": 1893,
+            "organization": {
+                "city": "",
+                "fec_page": "http://www.fec.gov/pubrec/cfsdd/widir.htm7",
+                "gov_agency": true,
+                "gov_level": "state",
+                "id": 17,
+                "name": "Wisconsin Elections Commission",
+                "resource_uri": "/api/v1/organization/17/",
+                "slug": "wi-gab",
+                "state": "WI",
+                "street": "",
+                "url": "http://elections.wi.gov/"
+            },
+            "portal_link": "https://elections.wi.gov/node/6697",
+            "precinct_level": true,
+            "precinct_level_status": "yes",
+            "prez": false,
+            "primary_note": "",
+            "primary_type": "open",
+            "race_type": "primary",
+            "resource_uri": "/api/v1/election/1893/",
+            "result_type": "certified",
+            "senate": false,
+            "special": true,
+            "start_date": "2020-02-18",
+            "state": {
+                "name": "Wisconsin",
+                "postal": "WI",
+                "resource_uri": "/api/v1/state/WI/"
+            },
+            "state_leg": false,
+            "state_leg_level": false,
+            "state_leg_level_status": "",
+            "state_level": false,
+            "state_level_status": "",
+            "state_officers": false,
+            "user_fullname": "Davies, Nick"
+        }
+    ]
+}


### PR DESCRIPTION
Includes two new elections, 1893 and 1894, both on 2020-02-18. I wasn't sure how to best produce the `WI/2020.json` file.